### PR TITLE
Update obsolete patch macro with autosetup

### DIFF
--- a/SPECS/libreswan.spec
+++ b/SPECS/libreswan.spec
@@ -37,7 +37,7 @@ Name: libreswan
 Summary: IPsec implementation with IKEv1 and IKEv2 keying protocols
 # version is generated in the release script
 Version: 4.12
-Release: 2.3.1%{?dist}
+Release: 2.3.2%{?dist}
 License: GPLv2
 Url: https://libreswan.org/
 
@@ -110,14 +110,7 @@ Libreswan also supports IKEv2 (RFC7296) and Secure Labeling
 Libreswan is based on Openswan-2.6.38 which in turn is based on FreeS/WAN-2.04
 
 %prep
-%setup -q -n libreswan-%{version}%{?prever}
-%patch1 -p1
-%patch2 -p1
-%patch3 -p1
-%patch6 -p1
-%patch7 -p1
-%patch8 -p1
-%patch1000 -p1
+%autosetup -n libreswan-%{version}%{?prever} -p1
 
 # linking to freebl is not needed
 sed -i "s/-lfreebl //" mk/config.mk
@@ -223,6 +216,10 @@ certutil -N -d sql:$tmpdir --empty-password
 %attr(0644,root,root) %doc %{_mandir}/*/*
 
 %changelog
+* Wed Apr 15 2026 Philippe Coval <philippe.coval@vates.tech> - 4.12-2.3.2
+- Rebuild with updated openssl
+- Update obsolete patch macro with autosetup
+
 * Fri Aug 16 2024 David Morel <david.morel@vates.tech> - 4.12-2.3.1
 - Sync with CentOS 8 Stream version 4.12-2.el8.3
 - Build with GCC 11


### PR DESCRIPTION
Modern distros will fail on parsing RPM since a breaking change in rpm-4.20+

Note that xcp-ng-8.3 currently uses rpm-4.11.3-32.el7.x86_64 (same for build env).

For the record:

https://rpm.org/releases/4.20.0

    Compatibility Notes The %patchN macro syntax (where N is a patch
    number) is now obsolete and will produce a build error.

    Use %patch N (or for maximum compatibility, %patch -P N) instead.

Relate-to: XCPNG-2882
Origin: https://github.com/xcp-ng-rpms/libreswan/pull

<!-- Please add any related context here (eg: public URLs, or private IDs) -->

Similar PRs in:
- [fuse](https://github.com/xcp-ng-rpms/fuse/pull/1)
- [drbd](https://github.com/xcp-ng-rpms/drbd/pull/10)
- [netdata](https://github.com/xcp-ng-rpms/netdata/pull/9)
- [slang](https://github.com/xcp-ng-rpms/slang/pull/3)
- [systemtap](https://github.com/xcp-ng-rpms/systemtap/pull/3)
