### PR TITLE
Fix: CVE-2026-12413, CVE-2026-50721 & CVE-2026-50722

### DIFF
--- a/SOURCES/libreswan-4.12-CVE-2026-12413.patch
+++ b/SOURCES/libreswan-4.12-CVE-2026-12413.patch
@@ -1,0 +1,27 @@
+From 8b6849151ec64ead0ac8f4d4d132f8a511badc53 Mon Sep 17 00:00:00 2001
+From: Paul Wouters <paul.wouters@aiven.io>
+Date: Tue, 16 Jun 2026 12:42:47 -0400
+Subject: [PATCH] Fix for CVE-2026-12413
+
+(cherry picked from commit 5c4369afcfe95a924ee0a96a0b29a7204dc40504)
+Related-to: https://libreswan.org/security/CVE-2026-12413/
+Forwarded: https://github.com/libreswan/libreswan/pull/2909
+Thanks-to: Lucas Ravagnier <lucas.ravagnier@vates.tech>
+Signed-off-by: Philippe Coval <philippe.coval@vates.tech>
+---
+ programs/pluto/ikev2_message.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/programs/pluto/ikev2_message.c b/programs/pluto/ikev2_message.c
+index 84b289ca8f..a691346218 100644
+--- a/programs/pluto/ikev2_message.c
++++ b/programs/pluto/ikev2_message.c
+@@ -1000,7 +1000,7 @@ struct msg_digest *reassemble_v2_incoming_fragments(struct v2_incoming_fragments
+ 	passert(md->chain[ISAKMP_NEXT_v2SK] == NULL);
+ 	passert(md->chain[ISAKMP_NEXT_v2SKF] != NULL);
+ 	pexpect(md->chain[ISAKMP_NEXT_v2SKF]->payload.v2skf.isaskf_number == 1);
+-	passert(md->digest_roof < elemsof(md->digest));
++	passert(md->digest_roof <= elemsof(md->digest));
+ 
+ 	/*
+ 	 * Pass 1: Compute the total payload size.

--- a/SOURCES/libreswan-4.12-CVE-2026-50721.patch
+++ b/SOURCES/libreswan-4.12-CVE-2026-50721.patch
@@ -1,0 +1,91 @@
+From f9647eee3c938c7b733b5bcc461bd5f75097b842 Mon Sep 17 00:00:00 2001
+From: Andrew Cagney <cagney@gnu.org>
+Date: Thu, 9 Apr 2026 21:02:51 -0400
+Subject: [PATCH] crypto: in RSA_authenticate_hash_signature_raw_rsa() use
+ PK11_Verify()
+
+[Philippe Coval]
+
+This backport change has been provided by upstream as an unauthored
+patch to fix CVE-2026-50721.
+
+(cherry picked from commit e06415f5c66bfaba5c43c04b7e312f57912cb1cc)
+Backported-by: https://libreswan.org/security/CVE-2026-50721/libreswan-4.15-CVE-2026-50721.patch
+Related-to: https://libreswan.org/security/CVE-2026-50721
+Forwarded: https://github.com/libreswan/libreswan/pull/2909
+Thanks-to: Lucas Ravagnier <lucas.ravagnier@vates.tech>
+Signed-off-by: Philippe Coval <philippe.coval@vates.tech>
+---
+ lib/libswan/pubkey_rsa.c | 52 ++++++----------------------------------
+ 1 file changed, 7 insertions(+), 45 deletions(-)
+
+diff --git a/lib/libswan/pubkey_rsa.c b/lib/libswan/pubkey_rsa.c
+index 38b44ab61d..d2f36cb3da 100644
+--- a/lib/libswan/pubkey_rsa.c
++++ b/lib/libswan/pubkey_rsa.c
+@@ -402,58 +402,20 @@ static bool RSA_authenticate_signature_raw_rsa(const struct crypt_mac *expected_
+ 			      *expected_hash);
+ 	}
+ 
+-	/*
+-	 * Use the same space used by the out going hash.
+-	 */
+-
+-	SECItem decrypted_signature = {
+-		.type = siBuffer,
+-	};
+-
+-	if (SECITEM_AllocItem(NULL, &decrypted_signature, signature.len) == NULL) {
+-		llog_nss_error(RC_LOG, logger, "allocating space for decrypted RSA signature");
+-		return false;
+-	}
+-
+ 	/* NSS doesn't do const */
+-	const SECItem encrypted_signature = {
+-		.type = siBuffer,
+-		.data = DISCARD_CONST(unsigned char *, signature.ptr),
+-		.len  = signature.len,
+-	};
+-
+-	if (PK11_VerifyRecover(seckey_public, &encrypted_signature, &decrypted_signature,
+-			       lsw_nss_get_password_context(logger)) != SECSuccess) {
+-		SECITEM_FreeItem(&decrypted_signature, PR_FALSE/*not-pointer*/);
+-		dbg("NSS RSA verify: decrypting signature is failed");
+-		*fatal_diag = NULL;
+-		return false;
+-	}
+ 
+-	if (DBGP(DBG_CRYPT)) {
+-		LLOG_JAMBUF(DEBUG_STREAM, logger, buf) {
+-			jam_string(buf, "NSS RSA verify: decrypted sig: ");
+-			jam_nss_secitem(buf, &decrypted_signature);
+-		}
+-	}
++	const SECItem signature_secitem =
++		same_shunk_as_secitem(signature, siBuffer);
++	const SECItem expected_hash_secitem =
++		same_shunk_as_secitem(HUNK_AS_SHUNK(*expected_hash), siBuffer);
+ 
+-	/*
+-	 * Expect the matching hash to appear at the end.  See above
+-	 * for length check.  It may, or may not, be prefixed by a
+-	 * PKCS#1 1.5 RSA ASN.1 blob.
+-	 */
+-	passert(decrypted_signature.len >= expected_hash->len);
+-	uint8_t *start = (decrypted_signature.data
+-			  + decrypted_signature.len
+-			  - expected_hash->len);
+-	if (!memeq(start, expected_hash->ptr, expected_hash->len)) {
+-		dbg("RSA Signature NOT verified");
+-		SECITEM_FreeItem(&decrypted_signature, PR_FALSE/*not-pointer*/);
++	if (PK11_Verify(seckey_public, &signature_secitem, &expected_hash_secitem,
++			lsw_nss_get_password_context(logger)) != SECSuccess) {
++		dbg("NSS RSA verify: decrypting signature is failed");
+ 		*fatal_diag = NULL;
+ 		return false;
+ 	}
+ 
+-	SECITEM_FreeItem(&decrypted_signature, PR_FALSE/*not-pointer*/);
+ 	*fatal_diag = NULL;
+ 	return true;
+ }

--- a/SOURCES/libreswan-4.12-CVE-2026-50722.patch
+++ b/SOURCES/libreswan-4.12-CVE-2026-50722.patch
@@ -1,0 +1,104 @@
+From 9356529612d25e03e864bf41cf08cd4847f38ca8 Mon Sep 17 00:00:00 2001
+From: Andrew Cagney <cagney@gnu.org>
+Date: Fri, 10 Apr 2026 00:25:19 -0400
+Subject: [PATCH] crypto: in RSA_authenticate_hash_signature_pkcs1_1_5_rsa()
+ use VFY_VerifyDigestDirect()
+
+[Philippe Coval]
+
+This backport change has been provided by upstream as an unauthored
+patch to fix CVE-2026-50722.
+
+(cherry picked from commit 232c26a4d6248818c542c1adf6f9f09583c7a87e)
+Backported-by: https://libreswan.org/security/CVE-2026-50722/libreswan-4.15-CVE-2026-50722.patch
+Related-to: Backported-by: https://libreswan.org/security/CVE-2026-50722
+Forwarded: https://github.com/libreswan/libreswan/pull/2909
+Thanks-to: Lucas Ravagnier <lucas.ravagnier@vates.tech>
+Signed-off-by: Philippe Coval <philippe.coval@vates.tech>
+---
+ lib/libswan/pubkey_rsa.c | 58 +++++++++-------------------------------
+ 1 file changed, 12 insertions(+), 46 deletions(-)
+
+diff --git a/lib/libswan/pubkey_rsa.c b/lib/libswan/pubkey_rsa.c
+index d2f36cb3da..0c5a1c91e3 100644
+--- a/lib/libswan/pubkey_rsa.c
++++ b/lib/libswan/pubkey_rsa.c
+@@ -491,7 +491,7 @@ static struct hash_signature RSA_sign_hash_pkcs1_1_5_rsa(const struct secret_stu
+ static bool RSA_authenticate_signature_pkcs1_1_5_rsa(const struct crypt_mac *expected_hash,
+ 						     shunk_t signature,
+ 						     struct pubkey *pubkey,
+-						     const struct hash_desc *unused_hash_algo UNUSED,
++						     const struct hash_desc *hash_alg,
+ 						     diag_t *fatal_diag,
+ 						     struct logger *logger)
+ {
+@@ -509,58 +509,24 @@ static bool RSA_authenticate_signature_pkcs1_1_5_rsa(const struct crypt_mac *exp
+ 			      *expected_hash);
+ 	}
+ 
+-	/*
+-	 * Use the same space used by the out going hash.
+-	 */
+-
+-	SECItem decrypted_signature = {
+-		.type = siBuffer,
+-	};
+-
+-	if (SECITEM_AllocItem(NULL, &decrypted_signature, signature.len) == NULL) {
+-		llog_nss_error(RC_LOG, logger, "allocating space for decrypted RSA signature");
+-		return false;
+-	}
++	SECItem hash_item =
++		same_shunk_as_secitem(HUNK_AS_SHUNK(*expected_hash), siBuffer);
+ 
+ 	/* NSS doesn't do const */
+-	const SECItem encrypted_signature = {
+-		.type = siBuffer,
+-		.data = DISCARD_CONST(unsigned char *, signature.ptr),
+-		.len  = signature.len,
+-	};
+-
+-	if (PK11_VerifyRecover(seckey_public, &encrypted_signature, &decrypted_signature,
+-			       lsw_nss_get_password_context(logger)) != SECSuccess) {
+-		SECITEM_FreeItem(&decrypted_signature, PR_FALSE/*not-pointer*/);
+-		dbg("NSS RSA verify: decrypting signature is failed");
+-		*fatal_diag = NULL;
+-		return false;
+-	}
+-
+-	if (DBGP(DBG_CRYPT)) {
+-		LLOG_JAMBUF(DEBUG_STREAM, logger, buf) {
+-			jam_string(buf, "NSS RSA verify: decrypted sig: ");
+-			jam_nss_secitem(buf, &decrypted_signature);
+-		}
+-	}
++	SECItem signature_item =
++		same_shunk_as_secitem(signature, siBuffer);
+ 
+-	/*
+-	 * Expect the matching hash to appear at the end.  See above
+-	 * for length check.  It may, or may not, be prefixed by a
+-	 * PKCS#1 1.5 RSA ASN.1 blob.
+-	 */
+-	passert(decrypted_signature.len >= expected_hash->len);
+-	uint8_t *start = (decrypted_signature.data
+-			  + decrypted_signature.len
+-			  - expected_hash->len);
+-	if (!memeq(start, expected_hash->ptr, expected_hash->len)) {
+-		dbg("RSA Signature NOT verified");
+-		SECITEM_FreeItem(&decrypted_signature, PR_FALSE/*not-pointer*/);
++	if (VFY_VerifyDigestDirect(&hash_item,
++				   seckey_public,
++				   &signature_item,
++				   /*pubkey algorithm*/SEC_OID_PKCS1_RSA_ENCRYPTION,
++				   /*hash algorithm*/hash_alg->nss.oid_tag,
++				   lsw_nss_get_password_context(logger)) != SECSuccess) {
++		ldbg_nss_error(logger, "NSS VFY_VerifyDigest() failed");
+ 		*fatal_diag = NULL;
+ 		return false;
+ 	}
+ 
+-	SECITEM_FreeItem(&decrypted_signature, PR_FALSE/*not-pointer*/);
+ 	*fatal_diag = NULL;
+ 	return true;
+ }

--- a/SPECS/libreswan.spec
+++ b/SPECS/libreswan.spec
@@ -37,7 +37,7 @@ Name: libreswan
 Summary: IPsec implementation with IKEv1 and IKEv2 keying protocols
 # version is generated in the release script
 Version: 4.12
-Release: 2.3.2%{?dist}
+Release: 2.3.3%{?dist}
 License: GPLv2
 Url: https://libreswan.org/
 
@@ -57,6 +57,9 @@ Patch8: libreswan-4.12-ikev2-auth-delete-state.patch
 
 # XCP-ng patches
 Patch1000: cve-2024-3652.patch
+Patch1001: libreswan-4.12-CVE-2026-12413.patch
+Patch1002: libreswan-4.12-CVE-2026-50721.patch
+Patch1003: libreswan-4.12-CVE-2026-50722.patch
 
 BuildRequires: audit-libs-devel
 BuildRequires: bison
@@ -216,6 +219,9 @@ certutil -N -d sql:$tmpdir --empty-password
 %attr(0644,root,root) %doc %{_mandir}/*/*
 
 %changelog
+* Mon Jun 29 2026 Lucas Ravagnier <lucas.ravagnier@vates.tech> - 4.12-2.3.3
+- Fix for CVE-2026-12413, CVE-2026-50721, CVE-2026-50722
+
 * Wed Apr 15 2026 Philippe Coval <philippe.coval@vates.tech> - 4.12-2.3.2
 - Rebuild with updated openssl
 - Update obsolete patch macro with autosetup


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3478

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

~~[ldns] The PR https://github.com/xcp-ng-rpms/ldns/pull/3 needs to be merged and built before this one. (BuildRequire)~~ (PR for ldns has been cancelled, this is not needed anymore)

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

This is a security update.
This fixes several security vulnerabilities in Libreswan, which is a necessary component for IPsec. This is lessened because we use OVS to manage the relationships; normally, there is no direct manipulation of Libreswan.

#### Release Target

- [x] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

The security team decided that it was not urgent, and that it would go through a classic update process.

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

Several fixes in Libreswan that could have allowed an attacker to cause a DoS. This only concerns IPsec, in XCP-ng this is only used for encrypted Global Private Networks.  This is lessened because we use OVS to manage the relationships; normally, there is no direct manipulation of Libreswan. That's why no VSA is needed

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

This fixes security vulnerabilities only. No functional changes.

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

There is no functional changes.

<!-- Add links to the documentation update PRs if/when they are created. -->

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

None, I don't know enough about IPsec.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

@bleader will conduct tests with IPsec.
Then before the release, we should encourage those who use IPsec to check that everything is working correctly.

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

Nothing currently. (We didn't test IPsec for the moment)

#### What tests have been or will be added to CI for this change? If none, explain why.

XCPNG-2880 exist to add test on private networks, updated to include encrypted tunnel as well.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
